### PR TITLE
fix: add missing polars requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ setup(
         'tqdm',
         'joblib',
         'pandas>=1.0.3',
+        'polars<1.0.0',
         'numpy>=1.18.1',
         'scikit-learn',
         'scipy',


### PR DESCRIPTION
add missing polars requirement as it is needed since: https://github.com/smazzanti/mrmr/commit/be8479a9544dc60a48778dfb78a5a48f9c3445f5
where polars support was included.

If polars is not meant to be used by default, further module management and maybe extra support for polars would be good to have.