### PR TITLE
fix: add missing polars requirement 2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,11 @@ setup(
         'numpy>=1.18.1',
         'scikit-learn',
         'scipy',
-        'polars>=0.12.5'
     ],
+    extras_require={
+        'polars': ['polars>=0.12.5'],
+        'pyspark': ['pyspark>=3.4.1'],
+        'bigquery': ['google.cloud.bigquery']
+    },
     zip_safe=False
 )

--- a/tests/test_polars.py
+++ b/tests/test_polars.py
@@ -8,12 +8,12 @@ target_column_regression = "target_regression"
 features = ["some_null", "feature_a", "constant", "feature_b"]
 
 df_polars = polars.DataFrame()
-df_polars = df_polars.with_column(polars.Series(['a','a','b','b','b']).alias("target_classif"))
-df_polars = df_polars.with_column(polars.Series([1.0,2.0,3.0,4.0,5.0]).alias("target_regression"))
-df_polars = df_polars.with_column(polars.Series([1.0,None,None,4.0,5.0]).alias("some_null"))
-df_polars = df_polars.with_column(polars.Series([2.0,2.0,3.0,3.0,4.0]).alias("feature_a"))
-df_polars = df_polars.with_column(polars.Series([7.0]*5).alias("constant"))
-df_polars = df_polars.with_column(polars.Series([3.0,2.0,1.0,2.0,3.0]).alias("feature_b"))
+df_polars = df_polars.with_columns(polars.Series(['a','a','b','b','b']).alias("target_classif")) 
+df_polars = df_polars.with_columns(polars.Series([1.0,2.0,3.0,4.0,5.0]).alias("target_regression"))
+df_polars = df_polars.with_columns(polars.Series([1.0,None,None,4.0,5.0]).alias("some_null"))
+df_polars = df_polars.with_columns(polars.Series([2.0,2.0,3.0,3.0,4.0]).alias("feature_a"))
+df_polars = df_polars.with_columns(polars.Series([7.0]*5).alias("constant"))
+df_polars = df_polars.with_columns(polars.Series([3.0,2.0,1.0,2.0,3.0]).alias("feature_b"))
 
 
 def test_mrmr_classif_without_scores():


### PR DESCRIPTION
As a response to the PR from "jose-turintech:patch-2" I have written a PR that adds the different flavors of MRMR as extras (polars, pyspark, bigquery). This should allow for "pip install mrmr_selection[polars] if you need the polars flavor.

Furthermore, in this way you do not have to install the extra packages unless needed, avoiding bloating your environment.

(This is my first official PR so please verify everything. I could not run all tests since I haven't set up pyspark and bigquery.