### PR TITLE
Fix polars correlation function

### DIFF
--- a/mrmr/polars.py
+++ b/mrmr/polars.py
@@ -40,7 +40,7 @@ def correlation(target_column, features, df):
     out = pd.Series(features, index=features).apply(
         lambda feature: df \
             .filter(~(pl.col(feature).is_null()) & ~(pl.col(target_column).is_null())) \
-            .select(pl.pearson_corr(feature, target_column))[0,0]
+            .select(pl.corr(feature, target_column, method="pearson"))[0,0]
     ).astype(float).fillna(0.0)
     return out
 


### PR DESCRIPTION
There is a new syntax for computing Pearson correlations in Polars, the previous one errors for me. It appears that `pearson_corr` is no longer a function in Polars.

https://docs.pola.rs/py-polars/html/reference/expressions/api/polars.corr.html

