### PR TITLE
Move `polars` to list of required packages

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,9 +24,9 @@ setup(
         'numpy>=1.18.1',
         'scikit-learn',
         'scipy',
+        'polars>=0.12.5',
     ],
     extras_require={
-        'polars': ['polars>=0.12.5'],
         'pyspark': ['pyspark>=3.4.1'],
         'bigquery': ['google.cloud.bigquery']
     },


### PR DESCRIPTION
Based on my user experience, `polars` seem to be as it is an required and not just an optional package.

---

I base this on the following error message,
```
  File "/home/conda/staged-recipes/build_artifacts/mrmr-selection_1715720114089/test_tmp/run_test.py", line 2, in <module>
    import mrmr
  File "/home/conda/staged-recipes/build_artifacts/mrmr-selection_1715720114089/_test_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_p/lib/python3.12/site-packages/mrmr/__init__.py", line 3, in <module>
    from . import polars
  File "/home/conda/staged-recipes/build_artifacts/mrmr-selection_1715720114089/_test_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_p/lib/python3.12/site-packages/mrmr/polars.py", line 3, in <module>
    import polars as pl
ModuleNotFoundError: No module named 'polars'
```
which I ran into [here](https://dev.azure.com/conda-forge/feedstock-builds/_build/results?buildId=934270&view=logs&j=6f142865-96c3-535c-b7ea-873d86b887bd&t=22b0682d-ab9e-55d7-9c79-49f3c3ba4823&l=818), trying to specify all necessary requirements for [adding the package to conda](https://github.com/conda-forge/staged-recipes/pull/26357).