### PR TITLE
M1fixes

### DIFF
--- a/mrmr/__init__.py
+++ b/mrmr/__init__.py
@@ -2,7 +2,8 @@ from importlib.metadata import version
 
 from mrmr import bigquery
 from mrmr import pandas
-from mrmr import polars
+# trigger: zsh: illegal hardware instructions if used with wrong package
+# from mrmr import polars
 from mrmr import spark
 from mrmr.pandas import mrmr_classif, mrmr_regression
 from mrmr.main import mrmr_base

--- a/mrmr/__init__.py
+++ b/mrmr/__init__.py
@@ -1,3 +1,5 @@
+from importlib.metadata import version
+
 from mrmr import bigquery
 from mrmr import pandas
 from mrmr import polars
@@ -5,4 +7,4 @@ from mrmr import spark
 from mrmr.pandas import mrmr_classif, mrmr_regression
 from mrmr.main import mrmr_base
 
-__version__ = "0.2.8"
+_version__ = version('mrmr_selection')

--- a/mrmr/__init__.py
+++ b/mrmr/__init__.py
@@ -1,8 +1,8 @@
-from . import bigquery
-from . import pandas
-from . import polars
-from . import spark
-from .pandas import mrmr_classif, mrmr_regression
-from .main import mrmr_base
+from mrmr import bigquery
+from mrmr import pandas
+from mrmr import polars
+from mrmr import spark
+from mrmr.pandas import mrmr_classif, mrmr_regression
+from mrmr.main import mrmr_base
 
 __version__ = "0.2.8"

--- a/mrmr/bigquery.py
+++ b/mrmr/bigquery.py
@@ -1,6 +1,6 @@
 import jinja2
 import numpy as np
-from .main import mrmr_base, groupstats2fstat
+from mrmr.main import mrmr_base, groupstats2fstat
 
 
 def get_numeric_features(bq_client, table_id, target_column):

--- a/mrmr/pandas.py
+++ b/mrmr/pandas.py
@@ -8,7 +8,7 @@ from sklearn.feature_selection import f_classif as sklearn_f_classif
 from sklearn.feature_selection import f_regression as sklearn_f_regression
 from scipy.stats import ks_2samp
 from sklearn.ensemble import RandomForestClassifier, RandomForestRegressor
-from .main import mrmr_base
+from mrmr.main import mrmr_base
 
 
 def parallel_df(func, df, series, n_jobs):

--- a/mrmr/polars.py
+++ b/mrmr/polars.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pandas as pd
 import polars as pl
-from .main import groupstats2fstat, mrmr_base
+from mrmr.main import groupstats2fstat, mrmr_base
 
 
 def get_numeric_features(df, target_column):

--- a/mrmr/spark.py
+++ b/mrmr/spark.py
@@ -1,6 +1,6 @@
 import numpy as np
 import pandas as pd
-from .main import groupstats2fstat, mrmr_base
+from mrmr.main import groupstats2fstat, mrmr_base
 
 
 def get_numeric_features(df, target_column):

--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,11 @@
 from setuptools import setup
-from mrmr import __version__
 
 with open("README.md", encoding="utf8") as f:
     long_description = f.read()
 
 setup(
     name='mrmr_selection',
-    version=__version__,
+    version='0.2.9',
     description='minimum-Redundancy-Maximum-Relevance algorithm for feature selection',
     long_description=long_description,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
I switched to direct imports, but this could be reverted...

### Do not import polars:

An issue for M1 Macs is polars, which needs to use the arm instructions. Apparently M1 Macs can use two versions of instructions, but I did not explore the details. Anyways

In mrmr-selection the line
```python
import polars
```

leads to `zsh: illegal hardware instruction.`

Therefore I suggest to only import polars if the functionality is requested.

### install from GitHub

Allow installation using: 

```bash
pip install git+https://github.com/smazzanti/mrmr.git
```

by moving version to metadata (`setup.py`) and importing the version in the package dynamically.

